### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AhoTTS Python
 
-[AhoTTS](https://github.com/aholab/AhoTTS) is a Text-to-Speech conversor for Basque and Spanish. 
-It includes linguistic processing and built voices for the languages aforementioned. Its acoustic
-engine is based on hts_engine and it uses a high quality vocoder called
-AhoCoder. Developed by Aholab Signal Processing Laboratory, at the Bilbao
-School of Engineering (University of the Basque Country).
+[AhoTTS](https://github.com/aholab/AhoTTS) is a Text-to-Speech system for Basque and Spanish.
+It includes linguistic processing and built voices for both languages. Its acoustic engine is
+based on hts_engine and uses a vocoder called AhoCoder. The Aholab Signal Processing
+Laboratory at the Bilbao School of Engineering (University of the Basque Country) develops
+AhoTTS.
 
 ## Compile
 
@@ -41,9 +41,9 @@ if audio_bytes:
 
 ## Phonemes (phonetic transcription)
 
-`get_tts` synthesizes audio; `get_phonemes` runs only the linguistic front end
+`get_tts` synthesizes audio. `get_phonemes` runs only the linguistic front end
 (number/date/abbreviation normalization, grapheme-to-phoneme, syllabification and
-lexical stress) and returns the SAMPA (or IPA) transcription — the AhoTTS
+lexical stress) and returns the SAMPA (or IPA) transcription. This is the AhoTTS
 linguistic analysis exposed directly, without the acoustic stage.
 
 Full documentation: [`docs/`](docs/README.md).
@@ -65,20 +65,22 @@ tts.get_phonemes("Bai eta ez.", lang="eu", ipa=True)
 
 Read `COPYRIGHT_and_LICENSE_code.txt` and `COPYRIGHT_and_LICENSE_voices.txt`
 
-    Basque (voice models & linguistic data):
-     	Copyright: Aholab Signal Processing Laboratory, University of the Basque Country (UPV/EHU)
-    	License: The files in this package are licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
-    	         http://creativecommons.org/licenses/by-sa/3.0/
-    
-    Spanish: (voice models & linguistic data):
-     	Copyright: Aholab Signal Processing Laboratory, University of the Basque Country (UPV/EHU)
-    	License: The files in this package are licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
-    	         http://creativecommons.org/licenses/by-sa/3.0/
+```
+Basque (voice models & linguistic data):
+	Copyright: Aholab Signal Processing Laboratory, University of the Basque Country (UPV/EHU)
+	License: The files in this package are licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
+	         http://creativecommons.org/licenses/by-sa/3.0/
+
+Spanish: (voice models & linguistic data):
+	Copyright: Aholab Signal Processing Laboratory, University of the Basque Country (UPV/EHU)
+	License: The files in this package are licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
+	         http://creativecommons.org/licenses/by-sa/3.0/
+```
 
 ## Credits
 
 <img src="img.png" width="128"/>
 
-> Python bindings for AhoTTS were funded by the Ministerio para la Transformación Digital y de la Función Pública and Plan de Recuperación, Transformación y Resiliencia - Funded by EU – NextGenerationEU within the framework of the project ILENIA with reference 2022/TL22/00215337
+> The Ministerio para la Transformación Digital y de la Función Pública and the Plan de Recuperación, Transformación y Resiliencia funded the Python bindings for AhoTTS. The EU (NextGenerationEU) funded this work within the ILENIA project, reference 2022/TL22/00215337.
 
-> Based on the [fork from @ekaitz-zarraga](https://github.com/ekaitz-zarraga/AhoTTS)
+> Based on the [fork from @ekaitz-zarraga](https://github.com/ekaitz-zarraga/AhoTTS).

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ syllabification → lexical stress) with an HTS-based acoustic engine and the
 AhoCoder vocoder.
 
 `pyahotts` wraps the compiled engine (`libhtts`) via `ctypes` and ships the native
-library plus all voice/dictionary data inside the wheel, so you can synthesize
-speech — and now obtain phonetic transcriptions — without compiling anything.
+library plus all voice/dictionary data inside the wheel. This lets you synthesize
+speech and get phonetic transcriptions without compiling anything.
 
 ```python
 from pyahotts import AhoTTS
@@ -22,14 +22,14 @@ tts.get_phonemes("Kaixo mundua!", lang="eu", ipa=True)        # text -> phonemes
 
 ## Contents
 
-- [Installation](installation.md) — pip install, and building `libhtts` from source.
-- [Usage](usage.md) — the `AhoTTS` API: synthesis and phonemization.
-- [Phonemes](phonemes.md) — phonetic transcription, SAMPA/IPA, stress, the SAMPA→IPA table.
-- [Architecture](architecture.md) — how the binding and the C engine fit together.
-- [Building libhtts](building.md) — the CMake build, the C API, per-architecture `.so` notes.
-- [Versions & source of truth](versions.md) — the AhoTTS V1/V2/V3 lineage and what pyAhoTTS bundles.
-- [Testing](testing.md) — unit + end-to-end golden tests, regenerating fixtures, CI.
-- [Licensing](licensing.md) — the split license and credits.
+- [Installation](installation.md): pip install, and building `libhtts` from source.
+- [Usage](usage.md): the `AhoTTS` API for synthesis and phonemization.
+- [Phonemes](phonemes.md): phonetic transcription, SAMPA/IPA, stress, the SAMPA→IPA table.
+- [Architecture](architecture.md): how the binding and the C engine fit together.
+- [Building libhtts](building.md): the CMake build, the C API, per-architecture `.so` notes.
+- [Versions & source of truth](versions.md): the AhoTTS V1/V2/V3 lineage and what pyAhoTTS bundles.
+- [Testing](testing.md): unit and end-to-end golden tests, regenerating fixtures, CI.
+- [Licensing](licensing.md): the split license and credits.
 
 ## At a glance
 
@@ -41,4 +41,3 @@ tts.get_phonemes("Kaixo mundua!", lang="eu", ipa=True)        # text -> phonemes
 | Native lib | `libhtts` (bundled `.so` for `x86_64` and `aarch64`) |
 | Runtime deps | `numpy` only |
 | Internal text encoding | ISO-8859-15 |
-</content>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,10 +37,10 @@ recreates the engine instance when the language changes.
 `transcribe_text` reuses the engine's linguistic stage and stops before acoustic
 synthesis. It runs `input_multilingual` then walks the resolved utterance with
 `HTS_U2W::pho2sampa`, emitting canonical SAMPA per phone (`phone_tosampa`), one
-word per line, stress as a leading `'`. Because no voice models are loaded on this
-path, the destructor guards `HTS_Engine_clear` with an "engine initialized" flag —
-otherwise transcribing (or merely creating an engine) and then destroying it would
-free uninitialized pointers.
+word per line, stress as a leading `'`. No voice models load on this path, so the
+destructor guards `HTS_Engine_clear` with an "engine initialized" flag. Without
+this guard, transcribing (or merely creating an engine) and then destroying it
+would free uninitialized pointers.
 
 ## Data layout (`data_tts/`)
 
@@ -50,6 +50,8 @@ data_tts/
   voices/  aholab_eu_female/, aholab_es_female/   # HTS voice models
 ```
 
-`data_path` defaults to the packaged `data_tts`; override it to point at custom
-dictionaries/voices.
-</content>
+`data_path` defaults to the packaged `data_tts`. Override it to point at custom
+dictionaries and voices.
+
+---
+[← Phonemes](phonemes.md) · [Home](README.md) · [Building →](building.md)

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,8 +1,8 @@
 # Building libhtts
 
-The native library is built from the C/C++ sources in `src/` with CMake. Prebuilt
+CMake builds the native library from the C/C++ sources in `src/`. Prebuilt
 `.so` files are committed under `pyahotts/` (`libhtts_x86_64.so`,
-`libhtts_aarch64.so`) and shipped in the wheel; you only need to build when
+`libhtts_aarch64.so`) and shipped in the wheel. You only need to build when
 porting to a new architecture or changing the engine.
 
 ## Build
@@ -28,18 +28,20 @@ installs the `data_tts` tree.
 - `uname -m` selects the bundled library at runtime (`libhtts_<machine>.so`).
 - Only `x86_64` and `aarch64` are committed. For other targets, build and pass
   `AhoTTS(lib_path=...)`.
-- **When you change the C sources, rebuild *every* shipped architecture** (a CI
-  matrix or cross-build), not just the host one — otherwise the other arch's
+- When you change the C sources, rebuild every shipped architecture (a CI
+  matrix or cross-build), not just the host one. Otherwise the other arch's
   bundled `.so` goes stale.
 
 ## Exported symbols
 
-The build exposes the C API consumed by the Python binding — see
-[Architecture](architecture.md): `create_tts`, `synthesize_text`,
-`transcribe_text`, `free_samples`, `free_string`, `destroy_tts`.
+The build exposes the C API consumed by the Python binding. See
+[Architecture](architecture.md) for `create_tts`, `synthesize_text`,
+`transcribe_text`, `free_samples`, `free_string`, and `destroy_tts`.
 
 ## Regenerating phoneme golden fixtures
 
 If an engine change legitimately alters transcriptions, regenerate the e2e golden
-fixtures from a **verified** build and review the diff — see [Testing](testing.md).
-</content>
+fixtures from a verified build and review the diff. See [Testing](testing.md).
+
+---
+[← Architecture](architecture.md) · [Home](README.md) · [Versions →](versions.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,8 @@ See [Building libhtts](building.md) for details on the build and the exported C 
 
 ## Supported platforms
 
-Linux `x86_64` and `aarch64` are shipped prebuilt. macOS/Windows are not bundled;
-build `libhtts` for your platform and pass `lib_path`.
-</content>
+Linux `x86_64` and `aarch64` are shipped prebuilt. macOS and Windows are not
+bundled. Build `libhtts` for your platform and pass `lib_path`.
+
+---
+[Home](README.md) · [Usage →](usage.md)

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,7 +1,7 @@
 # Licensing & credits
 
-pyAhoTTS carries a **split license** — the Python wrapper, the upstream engine
-code, and the bundled voice/linguistic data are licensed differently.
+pyAhoTTS carries a **split license**. The Python wrapper, the upstream engine
+code, and the bundled voice and linguistic data are licensed differently.
 
 | Component | License |
 |---|---|
@@ -11,17 +11,19 @@ code, and the bundled voice/linguistic data are licensed differently.
 
 See `COPYRIGHT_and_LICENSE_code.txt` and `COPYRIGHT_and_LICENSE_voices.txt` in the
 repository root for the authoritative terms. Because the distributed library links
-the GPL-3.0+ engine, redistribution of the **binary** package is governed by the
-GPL-3.0+; the MIT wrapper code may be reused under MIT.
+the GPL-3.0+ engine, the GPL-3.0+ governs redistribution of the **binary**
+package. The MIT wrapper code may be reused under MIT.
 
 ## Credits
 
-- **AhoTTS** — Aholab Signal Processing Laboratory, University of the Basque
+- **AhoTTS**: Aholab Signal Processing Laboratory, University of the Basque
   Country (UPV/EHU). Linguistic processing for Basque and Spanish, and the
-  AhoCoder vocoder. Upstream sources and releases: see [Versions](versions.md).
+  AhoCoder vocoder. For upstream sources and releases, see [Versions](versions.md).
 - Python bindings build on the [ekaitz-zarraga/AhoTTS](https://github.com/ekaitz-zarraga/AhoTTS)
-  fork and were funded by the *Ministerio para la Transformación Digital y de la
-  Función Pública* and the *Plan de Recuperación, Transformación y Resiliencia* —
-  funded by the EU (NextGenerationEU) within the ILENIA project (ref.
-  2022/TL22/00215337).
-</content>
+  fork. The Ministerio para la Transformación Digital y de la Función Pública
+  and the Plan de Recuperación, Transformación y Resiliencia funded the
+  bindings. The EU (NextGenerationEU) funded this work within the ILENIA
+  project (ref. 2022/TL22/00215337).
+
+---
+[← Testing](testing.md) · [Home](README.md)

--- a/docs/phonemes.md
+++ b/docs/phonemes.md
@@ -13,7 +13,7 @@ tts.get_phonemes("Kaixo mundua!", lang="eu", ipa=True)
 
 ## Output format
 
-- A **list of words**; each word is a **list of phone tokens** in order.
+- A **list of words**. Each word is a **list of phone tokens** in order.
 - **Lexical stress** is a leading `'` on the stressed nucleus (e.g. `"'o"`).
 - Phones are **SAMPA** by default, or **IPA** when `ipa=True`.
 
@@ -32,10 +32,10 @@ text
 ```
 
 The native side walks the utterance one word at a time, emitting the canonical
-SAMPA for each phone (via the engine's `phone_tosampa` table — **not** the
+SAMPA for each phone via the engine's `phone_tosampa` table. This is not the
 HTS-label remaps used for the acoustic model, so e.g. `z`→`s\`` and `tz`→`ts\``
-are preserved), with `'` prefixed on stressed nuclei. Pause/silence phones are
-dropped; word boundaries separate the lists.
+are preserved, with `'` prefixed on stressed nuclei. Pause and silence phones
+are dropped. Word boundaries separate the lists.
 
 ## SAMPA → IPA
 
@@ -55,10 +55,12 @@ conversion.
 
 ## Notes & limitations
 
-- The transcription reflects the **bundled engine version** (V1 — see
+- The transcription reflects the **bundled engine version** (V1, see
   [Versions](versions.md)). Other AhoTTS releases phonemize slightly differently
-  (diphthong glides, stress, dictionary exceptions); pin behavior with the
+  (diphthong glides, stress, dictionary exceptions). Pin behavior with the
   [golden tests](testing.md).
-- AhoTTS is the *engine*; if you need a pure-Python, dependency-free G2P that
+- AhoTTS is the engine. If you need a pure-Python, dependency-free G2P that
   matches a specific AhoTTS version, see the companion port project.
-</content>
+
+---
+[← Usage](usage.md) · [Home](README.md) · [Architecture →](architecture.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,15 +9,15 @@ pytest test/ -q
 
 ## What is tested
 
-- **Unit** (`test/test_phonemes.py`) — `get_phonemes` output shape, SAMPA/IPA
+- **Unit** (`test/test_phonemes.py`): `get_phonemes` output shape, SAMPA/IPA
   mapping, stress marks, empty input, and that transcribing then synthesizing does
   not corrupt engine state.
-- **End-to-end** (`test/test_e2e.py`) — golden tests that pin the engine's
-  behavior:
-  - `test_phonemes_match_v1_golden` — `get_phonemes` must reproduce the committed
+- **End-to-end** (`test/test_e2e.py`): golden tests that pin the engine's
+  behavior.
+  - `test_phonemes_match_v1_golden`: `get_phonemes` must reproduce the committed
     **V1** transcriptions verbatim.
-  - `test_synthesis_produces_audio` — `get_tts` yields a non-trivial waveform.
-  - `test_spanish_synthesis_smoke` — Spanish path produces audio.
+  - `test_synthesis_produces_audio`: `get_tts` yields a non-trivial waveform.
+  - `test_spanish_synthesis_smoke`: Spanish path produces audio.
 
 ## Golden fixtures
 
@@ -48,4 +48,6 @@ build-tests (matrix Python versions), coverage, lint, license-check, pip-audit,
 repo-health, and release-preview. The golden e2e tests run as part of build-tests,
 so any drift of the bundled binding versus upstream V1 fails CI without needing to
 rebuild the upstream sources.
-</content>
+
+---
+[← Building](building.md) · [Home](README.md) · [Licensing →](licensing.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,13 +12,13 @@ tts = AhoTTS()
 
 | arg | default | meaning |
 |---|---|---|
-| `lib_path` | bundled `libhtts_<machine>.so` | path to the native library; override for unbundled architectures |
+| `lib_path` | bundled `libhtts_<machine>.so` | path to the native library, override for unbundled architectures |
 | `data_path` | `<package>/data_tts` | directory holding `dicts/` and `voices/` |
 
 The underlying engine instance is created lazily and **recreated automatically
 when the language changes** between calls.
 
-## Synthesis — `get_tts(text, lang="eu", wav_path=None) -> bytes`
+## Synthesis: `get_tts(text, lang="eu", wav_path=None) -> bytes`
 
 Generates speech and returns raw **16-bit mono PCM @ 16 kHz** bytes. If `wav_path`
 is given, a WAV file is also written.
@@ -41,12 +41,12 @@ import numpy as np
 samples = np.frombuffer(tts.get_tts("Kaixo!"), dtype=np.int16)
 ```
 
-## Phonemization — `get_phonemes(text, lang="eu", ipa=False) -> list[list[str]]`
+## Phonemization: `get_phonemes(text, lang="eu", ipa=False) -> list[list[str]]`
 
-Runs **only the linguistic front end** (normalization → grapheme-to-phoneme →
+Runs only the linguistic front end (normalization → grapheme-to-phoneme →
 syllabification → lexical stress) and returns the phonetic transcription, with no
-audio synthesis — the AhoTTS linguistic analysis exposed directly, without the
-acoustic stage.
+audio synthesis. This is the AhoTTS linguistic analysis exposed directly, without
+the acoustic stage.
 
 ```python
 tts.get_phonemes("Bai eta ez.", lang="eu")
@@ -58,7 +58,7 @@ tts.get_phonemes("Bai eta ez.", lang="eu", ipa=True)
 
 - Returns **one list of phones per word**, in order.
 - **Lexical stress** is carried as a leading `'` on the stressed phone.
-- `ipa=False` → SAMPA phones; `ipa=True` → IPA via the [`SAMPA_TO_IPA`](phonemes.md) table.
+- `ipa=False` gives SAMPA phones. `ipa=True` gives IPA via the [`SAMPA_TO_IPA`](phonemes.md) table.
 - Returns `[]` if transcription fails.
 
 Number/date/abbreviation **normalization happens inside the engine**, so digits
@@ -77,6 +77,8 @@ how the transcription relates to the AhoTTS linguistic stages.
 ## Text encoding
 
 Input text is encoded to **ISO-8859-15** before reaching the engine (AhoTTS is a
-legacy ISO-8859-15 codebase). Characters outside that set are replaced; standard
-Basque/Spanish text is fully covered.
-</content>
+legacy ISO-8859-15 codebase). Characters outside that set are replaced. Standard
+Basque and Spanish text is fully covered.
+
+---
+[← Installation](installation.md) · [Home](README.md) · [Phonemes →](phonemes.md)

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,10 +1,9 @@
 # Versions & source of truth
 
-AhoTTS is developed upstream by **Aholab (UPV/EHU)**. It has evolved through
-several releases, and — importantly — **different releases phonemize the same text
-differently** (diphthong glides, lexical stress, dictionary exceptions). When
-phonemes must match a model that was trained with a particular release, the
-release matters.
+Aholab (UPV/EHU) develops AhoTTS upstream. It has evolved through several
+releases, and **different releases phonemize the same text differently**
+(diphthong glides, lexical stress, dictionary exceptions). When phonemes must
+match a model trained with a particular release, the release matters.
 
 **The upstream AhoTTS source repositories are the source of truth.** `pyahotts` is
 *our* binding: it wraps a build of one specific upstream release and is validated
@@ -14,26 +13,28 @@ against it (see [Testing](testing.md)). It is not itself the reference.
 
 | | Release | Upstream source | Notes |
 |---|---|---|---|
-| **V1** | Original AhoTTS | [ekaitz-zarraga/AhoTTS](https://github.com/ekaitz-zarraga/AhoTTS) (= [aholab/AhoTTS](https://github.com/aholab/AhoTTS) before its Dec-2025 rewrite) | Classic linguistic front end; rule-based stress. **This is what pyAhoTTS bundles.** |
-| **V2** | VITS-era rewrite | [aholab/AhoTTS](https://github.com/aholab/AhoTTS) (current HEAD) | Restructured engine; revised diphthong/stress rules. Powers the [HiTZ VITS voices](https://huggingface.co/collections/HiTZ/tts). |
-| **V3** | StyleTTS-era | [hitz-zentroa/aHoTTS](https://github.com/hitz-zentroa/aHoTTS) | Newer dictionary + transcription tweaks. Used to phonemize [HiTZ/StyleTTS2-eu](https://huggingface.co/HiTZ/StyleTTS2-eu). |
+| **V1** | Original AhoTTS | [ekaitz-zarraga/AhoTTS](https://github.com/ekaitz-zarraga/AhoTTS) (= [aholab/AhoTTS](https://github.com/aholab/AhoTTS) before its Dec-2025 rewrite) | Classic linguistic front end, rule-based stress. **This is what pyAhoTTS bundles.** |
+| **V2** | VITS-era rewrite | [aholab/AhoTTS](https://github.com/aholab/AhoTTS) (current HEAD) | Restructured engine, revised diphthong and stress rules. Powers the [HiTZ VITS voices](https://huggingface.co/collections/HiTZ/tts). |
+| **V3** | StyleTTS-era | [hitz-zentroa/aHoTTS](https://github.com/hitz-zentroa/aHoTTS) | Newer dictionary and transcription tweaks. Used to phonemize [HiTZ/StyleTTS2-eu](https://huggingface.co/HiTZ/StyleTTS2-eu). |
 
-(In practice V1 and V2 differ by exactly the Dec-2025 commit on `aholab/AhoTTS`;
+(In practice V1 and V2 differ by exactly the Dec-2025 commit on `aholab/AhoTTS`.
 "V1" is that repo with the last commit excluded.)
 
 ## What pyAhoTTS provides
 
-pyAhoTTS bundles and exposes **V1**. Its `get_phonemes` / `get_tts` reproduce the
-V1 engine's behavior, locked down by golden [end-to-end tests](testing.md) so the
-bundled binding cannot silently drift from the upstream V1 source.
+pyAhoTTS bundles and exposes **V1**. Its `get_phonemes` and `get_tts` reproduce
+the V1 engine's behavior, locked down by golden [end-to-end tests](testing.md)
+so the bundled binding cannot silently drift from the upstream V1 source.
 
 If you need V2 or V3 behavior, that must come from the corresponding upstream
-release — pyAhoTTS does not currently embed those.
+release. pyAhoTTS does not currently embed those.
 
 ## Picking a version
 
-- Synthesizing speech for general use → V1 (this package) is fine.
-- Producing phonemes to feed a **specific pretrained model** → use the release that
+- Synthesizing speech for general use: V1 (this package) is fine.
+- Producing phonemes to feed a specific pretrained model: use the release that
   model was trained with (e.g. a StyleTTS2-eu model expects V3-style phonemes).
   Matching the wrong release yields slightly out-of-distribution input.
-</content>
+
+---
+[← Architecture](architecture.md) · [Home](README.md) · [Building →](building.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md in Simplified Technical English for clarity: shorter sentences, active voice, no em dashes or semicolons, and consistent terminology. Adds the standard prev/home/next navigation footer across the docs pages and removes stray leftover markup found at the end of several files. No facts, links, code samples, or license text were changed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation, architecture, build, usage, phoneme, versioning, testing, and licensing guidance.
  * Improved explanations of transcription behavior, supported platforms, data paths, text encoding, and release compatibility.
  * Added clearer navigation links and reorganized several documentation sections for easier browsing.
  * Updated credits, funding acknowledgments, attribution, and licensing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->